### PR TITLE
Make sure package is built before shipping

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"start": "tsdx watch",
 		"build": "tsdx build",
 		"test": "tsdx build && tsdx test",
-		"lint": "tsdx lint src test/*.test.ts test/**/*.test.ts"
+		"lint": "tsdx lint src test/*.test.ts test/**/*.test.ts",
+		"prepublish": "yarn build"
 	},
 	"peerDependencies": {
 		"prisma": "^3.4.2",


### PR DESCRIPTION
Package version [0.2.4 on NPM](https://www.npmjs.com/package/zod-prisma/v/0.2.4) was published without being built, this should help avoid this situation by running the `build` script before publishing (and abort on build errors).