### PR TITLE
fix: Cast `field.type` to string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ generatorHandler({
 							new Set(
 								filteredFields.flatMap((f) => [
 									`Complete${f.type}`,
-									relatedModelName(f.type),
+									relatedModelName(String(f.type)),
 								])
 							)
 						),

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export const getZodConstructor = (
 	} else if (field.kind === 'enum') {
 		zodType = `z.nativeEnum(${field.type})`
 	} else if (field.kind === 'object') {
-		zodType = getRelatedModelName(field.type)
+		zodType = getRelatedModelName(String(field.type))
 	}
 
 	if (!field.isRequired) extraModifiers.push('nullable()')


### PR DESCRIPTION
Fixes the following errors with latest Prisma DMMF types:
```
Argument of type 'string | SchemaEnum | OutputType | SchemaArg' is not assignable to parameter of type 'string'.
  Type 'SchemaEnum' is not assignable to type 'string'.ts(2345)
```