### PR TITLE
feat: Add output formatting options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import { writeArray } from './util'
 
 interface Config {
 	relationModel: boolean | 'default'
+	modelSuffix?: string
+	modelCase?: 'PascalCase' | 'camelCase'
 }
 
 generatorHandler({
@@ -30,7 +32,18 @@ generatorHandler({
 			(each) => each.provider.value === 'prisma-client-js'
 		)
 
-		const { relationModel } = options.generator.config as unknown as Config
+		const {
+			relationModel,
+			modelSuffix = 'Model',
+			modelCase = 'PascalCase',
+		} = options.generator.config as unknown as Config
+
+		const formatModelName = (name: string, prefix = '') => {
+			if (modelCase === 'camelCase') {
+				name = name.slice(0, 1).toLowerCase() + name.slice(1)
+			}
+			return `${prefix}${name}${modelSuffix}`
+		}
 
 		const indexSource = project.createSourceFile(
 			`${outputPath}/index.ts`,
@@ -46,11 +59,12 @@ generatorHandler({
 			})
 
 			const modelName = (name: string) =>
-				relationModel === 'default' ? `_${name}Model` : `${name}Model`
+				formatModelName(name, relationModel === 'default' ? '_' : '')
+
 			const relatedModelName = (name: string) =>
-				relationModel === 'default'
-					? `${name}Model`
-					: `Related${name}Model`
+				formatModelName(
+					relationModel === 'default' ? name : `Related${name}`
+				)
 
 			const sourceFile = project.createSourceFile(
 				`${outputPath}/${model.name.toLowerCase()}.ts`,

--- a/test/functional/config/expected/post.ts
+++ b/test/functional/config/expected/post.ts
@@ -1,8 +1,8 @@
 import * as z from "zod"
 import { Post } from "@prisma/client"
-import { CompleteUser, UserModel } from "./index"
+import { CompleteUser, userSchema } from "./index"
 
-export const _PostModel = z.object({
+export const _postSchema = z.object({
   id: z.string(),
   title: z.string(),
   contents: z.string(),
@@ -14,10 +14,10 @@ export interface CompletePost extends Post {
 }
 
 /**
- * PostModel contains all relations on your model in addition to the scalars
+ * postSchema contains all relations on your model in addition to the scalars
  *
  * NOTE: Lazy required in case of potential circular dependencies within schema
  */
-export const PostModel: z.ZodSchema<CompletePost> = z.lazy(() => _PostModel.extend({
-  author: UserModel,
+export const postSchema: z.ZodSchema<CompletePost> = z.lazy(() => _postSchema.extend({
+  author: userSchema,
 }))

--- a/test/functional/config/expected/user.ts
+++ b/test/functional/config/expected/user.ts
@@ -1,8 +1,8 @@
 import * as z from "zod"
 import { User } from "@prisma/client"
-import { CompletePost, PostModel } from "./index"
+import { CompletePost, postSchema } from "./index"
 
-export const _UserModel = z.object({
+export const _userSchema = z.object({
   id: z.string(),
   name: z.string(),
   email: z.string(),
@@ -13,10 +13,10 @@ export interface CompleteUser extends User {
 }
 
 /**
- * UserModel contains all relations on your model in addition to the scalars
+ * userSchema contains all relations on your model in addition to the scalars
  *
  * NOTE: Lazy required in case of potential circular dependencies within schema
  */
-export const UserModel: z.ZodSchema<CompleteUser> = z.lazy(() => _UserModel.extend({
-  posts: PostModel.array(),
+export const userSchema: z.ZodSchema<CompleteUser> = z.lazy(() => _userSchema.extend({
+  posts: postSchema.array(),
 }))

--- a/test/functional/config/prisma/schema.prisma
+++ b/test/functional/config/prisma/schema.prisma
@@ -10,6 +10,8 @@ generator zod {
   provider      = "../../../bin/cli.js"
   output        = "../actual/"
   relationModel = "default"
+  modelCase     = "camelCase"
+  modelSuffix   = "Schema"
 }
 
 model User {


### PR DESCRIPTION
This adds two options to the configuration in the Prisma schema:
- `modelCase = "PascalCase" | "camelCase"` controls the casing of the generated objects.
- `modelSuffix = "Model"` controls the suffix added to the generated objects.

See #43.