### PR TITLE
fix: Explicitly cast `relationModel` to boolean

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,10 +33,16 @@ generatorHandler({
 		)
 
 		const {
-			relationModel,
 			modelSuffix = 'Model',
 			modelCase = 'PascalCase',
 		} = options.generator.config as unknown as Config
+
+		// config fields are strings and require an explicit cast to boolean:
+		const relationModel = options.generator.config.relationModel === 'false'
+			? false
+			: options.generator.config.relationModel === 'true'
+			? true
+			: 'default'
 
 		const formatModelName = (name: string, prefix = '') => {
 			if (modelCase === 'camelCase') {


### PR DESCRIPTION
Prisma config values are always strings, they need to be explicitly cast into a boolean for `relationModel = false` in the configuration to not generate relation models.