### PR TITLE
Adds optional json test case

### DIFF
--- a/test/functional/json/expected/user.ts
+++ b/test/functional/json/expected/user.ts
@@ -11,6 +11,7 @@ const jsonSchema: z.ZodSchema<Json> = z.lazy(() => z.union([literalSchema, z.arr
 export const UserModel = z.object({
   id: z.number().int(),
   meta: jsonSchema,
+  optionalMeta: jsonSchema.nullable(),
 })
 
 export interface CompleteUser extends User {

--- a/test/functional/json/prisma/schema.prisma
+++ b/test/functional/json/prisma/schema.prisma
@@ -17,9 +17,10 @@ generator zod {
 }
 
 model User {
-  id    Int    @id @default(autoincrement())
-  meta  Json
-  posts Post[]
+  id           Int    @id @default(autoincrement())
+  meta         Json
+  optionalMeta Json?
+  posts        Post[]
 }
 
 model Post {

--- a/test/functional/json/usage.ts
+++ b/test/functional/json/usage.ts
@@ -1,0 +1,20 @@
+import { UserModel } from './actual/user'
+import type { Prisma } from './prisma/.client'
+import { PrismaClient } from './prisma/.client'
+
+const input = UserModel.parse({
+  meta: {
+    name: 'hello',
+  },
+  optionalMeta: {
+    name: 'world',
+  },
+})
+
+const data: Prisma.UserCreateInput = input
+
+const prisma = new PrismaClient()
+
+prisma.user.create({
+  data,
+})


### PR DESCRIPTION
I don't know if this is intended but I found some weird behavior when using optional Json fields.

https://github.com/CarterGrimmeisen/zod-prisma/blob/4368d5aa921d70cd270ccaf856c078cf9c449d12/test/functional/json/usage.ts#L5-L20

When trying to consume some validated input to use in prisma we get this type error:

```
Type '{ id?: number; meta?: Json; optionalMeta?: Json; }' is not assignable to type 'UserCreateInput'.
  Property 'meta' is optional in type '{ id?: number; meta?: Json; optionalMeta?: Json; }' but required in type 'UserCreateInput'.
```