### PR TITLE
Handle Missing zod Dependency

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,3 +1,14 @@
 #!/usr/bin/env node
 
+try {
+	require('zod')
+} catch (error) {
+	if (error.code !== 'MODULE_NOT_FOUND') {
+		throw error
+	}
+	var RED = '\x1b[31m%s\x1b[0m'
+	console.error(RED, 'Please makes sure to install zod first.')
+	process.exit(1)
+}
+
 require('../dist/index')


### PR DESCRIPTION
This PR handles the case when `zod` is not installed, which currently fails silently without letting the user know why the generation step is stuck.