### PR TITLE
fix: inline comments cause prisma generate failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ npm install -g yarn
       modelCase                = "PascalCase"
       modelSuffix              = "Model"
       useDecimalJs             = true
-      imports                  = null
       prismaJsonNullability    = true
     }
     ```

--- a/README.md
+++ b/README.md
@@ -130,27 +130,26 @@ npm install -g yarn
     ```prisma
     generator zod {
       provider                 = "zod-prisma"
-      output                   = "./zod" // (default) the directory where generated zod schemas will be saved
-
-      relationModel            = true // (default) Create and export both plain and related models.
-      // relationModel         = "default" // Do not export model without relations.
-      // relationModel         = false // Do not generate related model
-
-      modelCase                = "PascalCase" // (default) Output models using pascal case (ex. UserModel, PostModel)
-      // modelCase             = "camelCase" // Output models using camel case (ex. userModel, postModel)
-
-      modelSuffix              = "Model" // (default) Suffix to apply to your prisma models when naming Zod schemas
-
-      // useDecimalJs          = false // (default) represent the prisma Decimal type using as a JS number
-      useDecimalJs             = true // represent the prisma Decimal type using Decimal.js (as Prisma does)
-
-      imports                  = null // (default) will import the referenced file in generated schemas to be used via imports.someExportedVariable
-
-      // https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-by-null-values
-      prismaJsonNullability    = true // (default) uses prisma's scheme for JSON field nullability
-      // prismaJsonNullability = false // allows null assignment to optional JSON fields
+      output                   = "./zod"
+      relationModel            = true
+      modelCase                = "PascalCase"
+      modelSuffix              = "Model"
+      useDecimalJs             = true
+      imports                  = null
+      prismaJsonNullability    = true
     }
     ```
+    	
+	#### Options
+	| Field                 | Type    | Default    | Description                                                                                                                                                                        |
+	|-----------------------|---------|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+	| output                | string  | ./zod      | The directory where generated zod schemas will be saved                                                                                                                            |
+	| relationModel         | boolean | true       | Create and export both plain and related models. Set to `false` to disable export without relations.                                                                               |
+	| modelCase             | string  | PascalCase | The casing of model names (ex UserModel, PostModel). Set to `camelCase` for (ex userMode, postModel)                                                                               |
+	| modelSuffix           | string  | Model      | Suffix to apply to your prisma models when naming Zod schemas                                                                                                                      |
+	| useDecimalJs          | boolean | false      | Represent the prisma Decimal type using Decimal.js (as Prisma does)                                                                                                                |
+	| imports               |         | null       | will import the referenced file in generated schemas to be used via imports.someExportedVariable                                                                                   |
+	| prismaJsonNullability | boolean | true       | Uses prisma's scheme for JSON field nullability https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields#filtering-by-null-values |
 
 3.  Run `npx prisma generate` or `yarn prisma generate` to generate your zod schemas
 4.  Import the generated schemas form your selected output location


### PR DESCRIPTION
I moved the inline comments to their own markdown table.
Someone who copies and pastes the default example will run into prisma generate errors that are a bit ambiguous.

Fixes: #110 