### PR TITLE
Feature/config for skip models

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ export const configSchema = z.object({
 	useDecimalJs: configBoolean.default('false'),
 	imports: z.string().optional(),
 	prismaJsonNullability: configBoolean.default('true'),
+	skipModels: z.string().array().default([])
 })
 
 export type Config = z.infer<typeof configSchema>

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,15 +1,16 @@
-import path from 'path'
-import { DMMF } from '@prisma/generator-helper'
+import { Config, PrismaOptions } from './config'
 import {
 	ImportDeclarationStructure,
 	SourceFile,
 	StructureKind,
 	VariableDeclarationKind,
 } from 'ts-morph'
-import { Config, PrismaOptions } from './config'
 import { dotSlash, needsRelatedModel, useModelNames, writeArray } from './util'
+
+import { DMMF } from '@prisma/generator-helper'
 import { getJSDocs } from './docs'
 import { getZodConstructor } from './types'
+import path from 'path'
 
 export const writeImportsForModel = (
 	model: DMMF.Model,
@@ -239,8 +240,8 @@ export const populateModelFile = (
 		generateRelatedSchemaForModel(model, sourceFile, config, prismaOptions)
 }
 
-export const generateBarrelFile = (models: DMMF.Model[], indexFile: SourceFile) => {
-	models.forEach((model) =>
+export const generateBarrelFile = (models: DMMF.Model[], indexFile: SourceFile, skipModels: string[]) => {
+	models.filter(model => !skipModels.includes(model.name)).forEach((model) =>
 		indexFile.addExportDeclaration({
 			moduleSpecifier: `./${model.name.toLowerCase()}`,
 		})

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ generatorHandler({
 			semicolons: SemicolonPreference.Remove,
 		})
 
-		models.filter(model => config.skipModels.includes(model.name)).forEach((model) => {
+		models.filter(model => !config.skipModels.includes(model.name)).forEach((model) => {
 			const sourceFile = project.createSourceFile(
 				`${outputPath}/${model.name.toLowerCase()}.ts`,
 				{},

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ generatorHandler({
 			{ overwrite: true }
 		)
 
-		generateBarrelFile(models, indexFile)
+		generateBarrelFile(models, indexFile, config.skipModels)
 
 		indexFile.formatText({
 			indentSize: 2,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
+import { PrismaOptions, configSchema } from './config'
+import { generateBarrelFile, populateModelFile } from './generator'
+
+import { Project } from 'ts-morph'
+import { SemicolonPreference } from 'typescript'
+import { generatorHandler } from '@prisma/generator-helper'
 // @ts-ignore Importing package.json for automated synchronization of version numbers
 import { version } from '../package.json'
-
-import { generatorHandler } from '@prisma/generator-helper'
-import { SemicolonPreference } from 'typescript'
-import { configSchema, PrismaOptions } from './config'
-import { populateModelFile, generateBarrelFile } from './generator'
-import { Project } from 'ts-morph'
 
 generatorHandler({
 	onManifest() {
@@ -33,6 +33,7 @@ generatorHandler({
 			)
 
 		const config = results.data
+
 		const prismaOptions: PrismaOptions = {
 			clientPath,
 			outputPath,
@@ -53,7 +54,7 @@ generatorHandler({
 			semicolons: SemicolonPreference.Remove,
 		})
 
-		models.forEach((model) => {
+		models.filter(model => config.skipModels.includes(model.name)).forEach((model) => {
 			const sourceFile = project.createSourceFile(
 				`${outputPath}/${model.name.toLowerCase()}.ts`,
 				{},


### PR DESCRIPTION
Adds a new configuration "skipModels" so that models can be excluded from file generation.

```
generator zod {
  provider      = "zod-prisma"
  output        = "../src/schemas"
  modelSuffix   = "Schema"
  relationModel = false
  skipModels    = ["SignIn", "SignUp"]
}
```